### PR TITLE
✨강사 등록 기능

### DIFF
--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/security/config/SecurityConfig.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/security/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(
                 (authorizeHttpRequests) -> authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers("/admins/**").hasRole("ADMIN")
                         .requestMatchers("/users/**").permitAll()
                         .anyRequest().authenticated()
 

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/controller/TeacherController.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/controller/TeacherController.java
@@ -1,0 +1,26 @@
+package com.sparta.spartalecture.teacher.controller;
+
+import com.sparta.spartalecture.teacher.dto.TeacherRegistrationRequestDto;
+import com.sparta.spartalecture.teacher.dto.TeacherRegistrationResponseDto;
+import com.sparta.spartalecture.teacher.service.TeacherService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TeacherController {
+
+    private final TeacherService teacherService;
+
+    @PostMapping("/admins/teachers")
+    public ResponseEntity<TeacherRegistrationResponseDto> registerTeacher(@RequestBody @Valid TeacherRegistrationRequestDto requestDto) {
+        TeacherRegistrationResponseDto responseDto = teacherService.registerTeacher(requestDto);
+        return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+    }
+
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/domain/Teacher.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/domain/Teacher.java
@@ -1,0 +1,43 @@
+package com.sparta.spartalecture.teacher.domain;
+
+import com.sparta.spartalecture.teacher.dto.TeacherRegistrationRequestDto;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "teacher")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Teacher {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "teacher_id")
+    private Long id;
+
+    @Column(name = "name", length = 5, nullable = false)
+    private String name;
+
+    @Column(name = "experience", nullable = false)
+    private int experience;
+
+    @Column(name = "company", length = 50, nullable = false)
+    private String company;
+
+    @Column(name = "phone", length = 20, nullable = false, unique = true)
+    private String phone;
+
+    @Column(name = "introduce", length = 150, nullable = false)
+    private String introduce;
+
+    public static Teacher from(TeacherRegistrationRequestDto requestDto) {
+        return Teacher.builder()
+                .name(requestDto.getName())
+                .experience(requestDto.getExperience())
+                .company(requestDto.getCompany())
+                .phone(requestDto.getPhone())
+                .introduce(requestDto.getIntroduce())
+                .build();
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/dto/TeacherRegistrationRequestDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/dto/TeacherRegistrationRequestDto.java
@@ -1,0 +1,21 @@
+package com.sparta.spartalecture.teacher.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class TeacherRegistrationRequestDto {
+    @NotBlank(message = "값을 입력하지 않았습니다")
+    private String name;
+
+    private int experience;
+
+    @NotBlank(message = "값을 입력하지 않았습니다")
+    private String company;
+
+    @NotBlank(message = "값을 입력하지 않았습니다")
+    private String phone;
+
+    @NotBlank(message = "값을 입력하지 않았습니다")
+    private String introduce;
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/dto/TeacherRegistrationResponseDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/dto/TeacherRegistrationResponseDto.java
@@ -1,0 +1,28 @@
+package com.sparta.spartalecture.teacher.dto;
+
+import com.sparta.spartalecture.teacher.domain.Teacher;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TeacherRegistrationResponseDto {
+    private Long id;
+    private String name;
+    private int experience;
+    private String company;
+    private String phone;
+    private String introduce;
+
+    public static TeacherRegistrationResponseDto from(Teacher teacher) {
+        return TeacherRegistrationResponseDto.builder()
+                .id(teacher.getId())
+                .name(teacher.getName())
+                .experience(teacher.getExperience())
+                .company(teacher.getCompany())
+                .phone(teacher.getPhone())
+                .introduce(teacher.getIntroduce())
+                .build();
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/repository/TeacherRepository.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/repository/TeacherRepository.java
@@ -1,0 +1,8 @@
+package com.sparta.spartalecture.teacher.repository;
+
+import com.sparta.spartalecture.teacher.domain.Teacher;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeacherRepository extends JpaRepository<Teacher, Long> {
+    boolean existsByPhone(String phone);
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/service/TeacherService.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/service/TeacherService.java
@@ -1,0 +1,29 @@
+package com.sparta.spartalecture.teacher.service;
+
+import com.sparta.spartalecture.teacher.domain.Teacher;
+import com.sparta.spartalecture.teacher.dto.TeacherRegistrationRequestDto;
+import com.sparta.spartalecture.teacher.dto.TeacherRegistrationResponseDto;
+import com.sparta.spartalecture.teacher.repository.TeacherRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TeacherService {
+
+    private final TeacherRepository teacherRepository;
+
+    public TeacherRegistrationResponseDto registerTeacher(TeacherRegistrationRequestDto requestDto) {
+
+        // 이미 존재하는 강사인지 확인
+        if (teacherRepository.existsByPhone(requestDto.getPhone())) {
+            throw new RuntimeException("이미 존재하는 강사입니다.");
+        }
+
+        // 새로운 강사 등록
+        Teacher newTeacher = Teacher.from(requestDto);
+        teacherRepository.save(newTeacher);
+
+        return TeacherRegistrationResponseDto.from(newTeacher);
+    }
+}


### PR DESCRIPTION
### 요약
강사 등록 기능 구현

### 작업사항
- 강사 등록 요청, 응답 dto 생성
- 강사 등록 api 구현
- ADMIN 권한을 가진 사용자만 등록할 수 있도록 주소에 권한 설정

### 완료사항
- [x]  강사 등록 기능
    - `이름`, `경력(년차)`, `회사`, `전화번호`, `소개`를 저장할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - ADMIN 권한을 가진 회원만 강사 등록이 가능합니다.
    - 등록된 강사의 정보를 반환 받아 확인할 수 있습니다.