### PR TITLE
✨강의 등록, 선택한 강의 조회, 카테고리별 강의 목록 조회 기능

### DIFF
--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/SpartaLectureApplication.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/SpartaLectureApplication.java
@@ -2,7 +2,9 @@ package com.sparta.spartalecture;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SpartaLectureApplication {
 

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/global/exception/CustomException.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/global/exception/CustomException.java
@@ -1,0 +1,22 @@
+package com.sparta.spartalecture.global.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+public class CustomException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    public CustomException (CustomExceptionCode code) {
+        this(code.getStatus(), code.getMessage());
+    }
+
+    public CustomException (HttpStatus status, String message) {
+        super(message);
+        this.status = status;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/global/exception/CustomExceptionCode.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/global/exception/CustomExceptionCode.java
@@ -1,0 +1,17 @@
+package com.sparta.spartalecture.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CustomExceptionCode {
+
+    MEMBER_EXISTS(HttpStatus.CONFLICT, "해당 이메일의 회원이 이미 존재합니다."),
+    TEACHER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강사는 존재하지 않습니다."),
+    LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강의는 존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/global/exception/GlobalExceptionHandler.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -28,6 +29,12 @@ public class GlobalExceptionHandler {
                     .append("}, ");
         }
         return new ResponseEntity<>(getResponse(errorMessage.toString(), HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<Map<String, String>> handleMissingRequestParamException(MissingServletRequestParameterException e) {
+        String errorMessage = e.getParameterName() + " : 값이 존재하지 않습니다.";
+        return new ResponseEntity<>(getResponse(errorMessage, HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(CustomException.class)

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/global/exception/GlobalExceptionHandler.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/global/exception/GlobalExceptionHandler.java
@@ -30,6 +30,11 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(getResponse(errorMessage.toString(), HttpStatus.BAD_REQUEST), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<Map<String, String>> handleCustomException(CustomException e) {
+        return new ResponseEntity<>(getResponse(e.getMessage(), e.getStatus()), e.getStatus());
+    }
+
     private Map<String, String> getResponse(String errorMessage, HttpStatus status) {
         Map<String, String> response = new HashMap<>();
         response.put("error type", status.getReasonPhrase());

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/controller/LectureController.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/controller/LectureController.java
@@ -1,5 +1,6 @@
 package com.sparta.spartalecture.lecture.controller;
 
+import com.sparta.spartalecture.lecture.dto.LectureInfoResponseDto;
 import com.sparta.spartalecture.lecture.dto.LectureRegistrationRequestDto;
 import com.sparta.spartalecture.lecture.dto.LectureRegistrationResponseDto;
 import com.sparta.spartalecture.lecture.service.LectureService;
@@ -7,9 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,4 +22,9 @@ public class LectureController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
+    @GetMapping("/lectures/{lectureId}")
+    public ResponseEntity<LectureInfoResponseDto> getLecture(@PathVariable Long lectureId) {
+        LectureInfoResponseDto responseDto = lectureService.getLecture(lectureId);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
 }

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/controller/LectureController.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/controller/LectureController.java
@@ -1,0 +1,26 @@
+package com.sparta.spartalecture.lecture.controller;
+
+import com.sparta.spartalecture.lecture.dto.LectureRegistrationRequestDto;
+import com.sparta.spartalecture.lecture.dto.LectureRegistrationResponseDto;
+import com.sparta.spartalecture.lecture.service.LectureService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LectureController {
+
+    private final LectureService lectureService;
+
+    @PostMapping("/admins/lectures")
+    public ResponseEntity<LectureRegistrationResponseDto> registerLecture(@RequestBody @Valid LectureRegistrationRequestDto requestDto) {
+        LectureRegistrationResponseDto responseDto = lectureService.registerLecture(requestDto);
+        return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+    }
+
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/controller/LectureController.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/controller/LectureController.java
@@ -1,14 +1,19 @@
 package com.sparta.spartalecture.lecture.controller;
 
+import com.sparta.spartalecture.lecture.dto.LectureInfoByCategoryDto;
 import com.sparta.spartalecture.lecture.dto.LectureInfoResponseDto;
 import com.sparta.spartalecture.lecture.dto.LectureRegistrationRequestDto;
 import com.sparta.spartalecture.lecture.dto.LectureRegistrationResponseDto;
 import com.sparta.spartalecture.lecture.service.LectureService;
+import com.sparta.spartalecture.lecture.type.Category;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +31,15 @@ public class LectureController {
     public ResponseEntity<LectureInfoResponseDto> getLecture(@PathVariable Long lectureId) {
         LectureInfoResponseDto responseDto = lectureService.getLecture(lectureId);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    @GetMapping("/lectures/categories/{category}")
+    public ResponseEntity<Page<LectureInfoByCategoryDto>> getLecturesByCategory(@PathVariable Category category,
+                                                                                @RequestParam("sortBy") String sortBy,
+                                                                                @RequestParam("page") int page,
+                                                                                @RequestParam("size") int size,
+                                                                                @RequestParam("isAsc") boolean isAsc) {
+        Page<LectureInfoByCategoryDto> responseDtoList = lectureService.getLecturesByCategory(category, page-1, size, sortBy, isAsc);
+        return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
     }
 }

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/controller/LectureController.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/controller/LectureController.java
@@ -13,8 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 public class LectureController {

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/domain/Lecture.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/domain/Lecture.java
@@ -1,0 +1,47 @@
+package com.sparta.spartalecture.lecture.domain;
+
+import com.sparta.spartalecture.lecture.dto.LectureRegistrationRequestDto;
+import com.sparta.spartalecture.lecture.type.Category;
+import com.sparta.spartalecture.teacher.domain.Teacher;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "lecture")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Lecture extends Timestamped {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "lecture_id")
+    private Long id;
+
+    @Column(name = "title", length = 50, nullable = false)
+    private String title;
+
+    @Column(name = "price", nullable = false)
+    private int price;
+
+    @Column(name = "introduce", length = 150, nullable = false)
+    private String introduce;
+
+    @Column(name = "category", length = 50, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "teacher_id")
+    private Teacher teacher;
+
+    public static Lecture of(LectureRegistrationRequestDto requestDto, Teacher teacher) {
+        return Lecture.builder()
+                .title(requestDto.getTitle())
+                .price(requestDto.getPrice())
+                .introduce(requestDto.getIntroduce())
+                .category(requestDto.getCategory())
+                .teacher(teacher)
+                .build();
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/domain/Timestamped.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/domain/Timestamped.java
@@ -1,0 +1,19 @@
+package com.sparta.spartalecture.lecture.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Timestamped {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureInfoByCategoryDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureInfoByCategoryDto.java
@@ -1,0 +1,33 @@
+package com.sparta.spartalecture.lecture.dto;
+
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.lecture.type.Category;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class LectureInfoByCategoryDto {
+    private Long id;
+    private String title;
+    private int price;
+    private String introduce;
+    private Category category;
+    private LocalDateTime createdAt;
+    private Long teacherId;
+
+    public static LectureInfoByCategoryDto from(Lecture lecture) {
+        return LectureInfoByCategoryDto.builder()
+                .id(lecture.getId())
+                .title(lecture.getTitle())
+                .price(lecture.getPrice())
+                .introduce(lecture.getIntroduce())
+                .category(lecture.getCategory())
+                .createdAt(lecture.getCreatedAt())
+                .teacherId(lecture.getTeacher().getId())
+                .build();
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureInfoResponseDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureInfoResponseDto.java
@@ -1,0 +1,35 @@
+package com.sparta.spartalecture.lecture.dto;
+
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.lecture.type.Category;
+import com.sparta.spartalecture.teacher.dto.TeacherInfoResponseDto;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class LectureInfoResponseDto {
+
+    private Long id;
+    private String title;
+    private int price;
+    private String introduce;
+    private Category category;
+    private LocalDateTime createdAt;
+    private TeacherInfoResponseDto teacher;
+
+    public static LectureInfoResponseDto from(Lecture lecture) {
+        return LectureInfoResponseDto.builder()
+                .id(lecture.getId())
+                .title(lecture.getTitle())
+                .price(lecture.getPrice())
+                .introduce(lecture.getIntroduce())
+                .category(lecture.getCategory())
+                .createdAt(lecture.getCreatedAt())
+                .teacher(TeacherInfoResponseDto.from(lecture.getTeacher()))
+                .build();
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureRegistrationRequestDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureRegistrationRequestDto.java
@@ -1,0 +1,23 @@
+package com.sparta.spartalecture.lecture.dto;
+
+import com.sparta.spartalecture.lecture.type.Category;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class LectureRegistrationRequestDto {
+    @NotBlank(message = "값을 입력하지 않았습니다.")
+    private String title;
+
+    private int price;
+
+    @NotBlank(message = "값을 입력하지 않았습니다.")
+    private String introduce;
+
+    @NotNull(message = "값을 입력하지 않았습니다.")
+    private Category category;
+
+    @NotNull(message = "값을 입력하지 않았습니다.")
+    private Long teacherId;
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureRegistrationResponseDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureRegistrationResponseDto.java
@@ -1,0 +1,32 @@
+package com.sparta.spartalecture.lecture.dto;
+
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.lecture.type.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class LectureRegistrationResponseDto {
+    private Long id;
+    private String title;
+    private int price;
+    private String introduce;
+    private Category category;
+    private Long teacherId;
+    private LocalDateTime createdAt;
+
+    public static LectureRegistrationResponseDto from(Lecture lecture) {
+        return LectureRegistrationResponseDto.builder()
+                .id(lecture.getId())
+                .title(lecture.getTitle())
+                .price(lecture.getPrice())
+                .introduce(lecture.getIntroduce())
+                .category(lecture.getCategory())
+                .teacherId(lecture.getTeacher().getId())
+                .createdAt(lecture.getCreatedAt())
+                .build();
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/repository/LectureRepository.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/repository/LectureRepository.java
@@ -1,7 +1,11 @@
 package com.sparta.spartalecture.lecture.repository;
 
 import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.lecture.type.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
+    Page<Lecture> findAllByCategory(Category category, Pageable pageable);
 }

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/repository/LectureRepository.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/repository/LectureRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.spartalecture.lecture.repository;
+
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LectureRepository extends JpaRepository<Lecture, Long> {
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
@@ -3,6 +3,7 @@ package com.sparta.spartalecture.lecture.service;
 import com.sparta.spartalecture.global.exception.CustomException;
 import com.sparta.spartalecture.global.exception.CustomExceptionCode;
 import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.lecture.dto.LectureInfoResponseDto;
 import com.sparta.spartalecture.lecture.dto.LectureRegistrationRequestDto;
 import com.sparta.spartalecture.lecture.dto.LectureRegistrationResponseDto;
 import com.sparta.spartalecture.lecture.repository.LectureRepository;
@@ -27,6 +28,16 @@ public class LectureService {
         lectureRepository.save(newLecture);
 
         return LectureRegistrationResponseDto.from(newLecture);
+    }
+
+    public LectureInfoResponseDto getLecture(Long lectureId) {
+        Lecture lecture = findLecture(lectureId);
+        return LectureInfoResponseDto.from(lecture);
+    }
+
+    private Lecture findLecture(Long lectureId) {
+        return lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.LECTURE_NOT_FOUND));
     }
 
     private Teacher findTeacher (Long teacherId) {

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
@@ -3,14 +3,23 @@ package com.sparta.spartalecture.lecture.service;
 import com.sparta.spartalecture.global.exception.CustomException;
 import com.sparta.spartalecture.global.exception.CustomExceptionCode;
 import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.lecture.dto.LectureInfoByCategoryDto;
 import com.sparta.spartalecture.lecture.dto.LectureInfoResponseDto;
 import com.sparta.spartalecture.lecture.dto.LectureRegistrationRequestDto;
 import com.sparta.spartalecture.lecture.dto.LectureRegistrationResponseDto;
 import com.sparta.spartalecture.lecture.repository.LectureRepository;
+import com.sparta.spartalecture.lecture.type.Category;
 import com.sparta.spartalecture.teacher.domain.Teacher;
 import com.sparta.spartalecture.teacher.repository.TeacherRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +42,14 @@ public class LectureService {
     public LectureInfoResponseDto getLecture(Long lectureId) {
         Lecture lecture = findLecture(lectureId);
         return LectureInfoResponseDto.from(lecture);
+    }
+
+    public Page<LectureInfoByCategoryDto> getLecturesByCategory(Category category, int page, int size, String sortBy, boolean isAsc) {
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Page<Lecture> lectureList = lectureRepository.findAllByCategory(category, pageable);
+        return lectureList.map(LectureInfoByCategoryDto::from);
     }
 
     private Lecture findLecture(Long lectureId) {

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
@@ -1,0 +1,36 @@
+package com.sparta.spartalecture.lecture.service;
+
+import com.sparta.spartalecture.global.exception.CustomException;
+import com.sparta.spartalecture.global.exception.CustomExceptionCode;
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.lecture.dto.LectureRegistrationRequestDto;
+import com.sparta.spartalecture.lecture.dto.LectureRegistrationResponseDto;
+import com.sparta.spartalecture.lecture.repository.LectureRepository;
+import com.sparta.spartalecture.teacher.domain.Teacher;
+import com.sparta.spartalecture.teacher.repository.TeacherRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LectureService {
+
+    private final LectureRepository lectureRepository;
+    private final TeacherRepository teacherRepository;
+
+    public LectureRegistrationResponseDto registerLecture(LectureRegistrationRequestDto requestDto) {
+
+        // 강사 존재 여부 확인
+        Teacher teacher = findTeacher(requestDto.getTeacherId());
+
+        Lecture newLecture = Lecture.of(requestDto, teacher);
+        lectureRepository.save(newLecture);
+
+        return LectureRegistrationResponseDto.from(newLecture);
+    }
+
+    private Teacher findTeacher (Long teacherId) {
+        return teacherRepository.findById(teacherId)
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.TEACHER_NOT_FOUND));
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
@@ -18,9 +18,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class LectureService {

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/type/Category.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/type/Category.java
@@ -1,0 +1,7 @@
+package com.sparta.spartalecture.lecture.type;
+
+public enum Category {
+    SPRING,
+    REACT,
+    NODE
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/security/config/SecurityConfig.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/security/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers("/admins/**").hasRole("ADMIN")
                         .requestMatchers("/users/**").permitAll()
+                        .requestMatchers("/lectures/**").permitAll()
                         .anyRequest().authenticated()
 
         );

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/dto/TeacherInfoResponseDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/teacher/dto/TeacherInfoResponseDto.java
@@ -1,0 +1,26 @@
+package com.sparta.spartalecture.teacher.dto;
+
+import com.sparta.spartalecture.teacher.domain.Teacher;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TeacherInfoResponseDto {
+    private Long id;
+    private String name;
+    private int experience;
+    private String company;
+    private String introduce;
+
+    public static TeacherInfoResponseDto from(Teacher teacher) {
+        return TeacherInfoResponseDto.builder()
+                .id(teacher.getId())
+                .name(teacher.getName())
+                .experience(teacher.getExperience())
+                .company(teacher.getCompany())
+                .introduce(teacher.getIntroduce())
+                .build();
+    }
+}


### PR DESCRIPTION
### 요약
강의 등록, 선택한 강의 조회, 카테고리별 강의 목록 조회 기능 구현

### 작업사항
- Validation을 통해 LectureRegistrationDto 유효성 검증 후 강의 등록하는 api 구현
- 선택한 강의 조회 api 구현
- 카테고리별 강의 목록 조회 기능 api 구현
- 강의 조회 시 발생하는 예외 처리
 
### 완료사항
- [x]  강의 등록 기능
    - `강의명`, `가격`, `소개`, `카테고리`, `강사`, `등록일`을 저장할 수 있습니다.
        - Spring, React, Node `카테고리`가 있습니다.
        - 강사 한 명이 여러 개의 강의를 촬영할 수도 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - ADMIN 권한을 가진 회원만 강의 등록이 가능합니다.
    - 등록된 강의의 정보를 반환 받아 확인할 수 있습니다.
- [x]  선택한 강의 조회 기능
    - 선택한 강의의 정보를 조회할 수 있습니다.
        - 모든 사용자가 강의를 조회할 수 있습니다.
        - 강의를 촬영한 강사의 정보를 확인할 수 있습니다.
            - 강사의 정보에 `전화번호`는 제외 되어있습니다.
- [x]  카테고리별 강의 목록 조회 기능
    - 선택한 `카테고리`에 포함된 강의를 조회할 수 있습니다.
        - 모든 사용자가 강의를 조회할 수 있습니다.
        - 강사의 정보는 제외됩니다.
    - 조회된 강의 목록은 선택한 기준에 의해 정렬됩니다.
        - `강의명`, `가격`, `등록일` 중 기준을 선택할 수 있습니다.
        - 내림차순, 오름차순을 선택할 수 있습니다. 