### PR TITLE
✨선택한 강의 댓글 기능, 선택한 강의 선택한 댓글 수정 기능, 선택한 강의 선택한 댓글 삭제 기능

### DIFF
--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/controller/CommentController.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/controller/CommentController.java
@@ -1,16 +1,14 @@
 package com.sparta.spartalecture.comment.controller;
 
 import com.sparta.spartalecture.comment.dto.CommentCreateRequestDto;
+import com.sparta.spartalecture.comment.dto.CommentUpdateRequestDto;
 import com.sparta.spartalecture.comment.service.CommentService;
 import com.sparta.spartalecture.security.service.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,9 +18,17 @@ public class CommentController {
 
     @PostMapping("/lectures/{lectureId}/comments")
     public ResponseEntity<Void> createComment(@RequestBody CommentCreateRequestDto requestDto,
-                                                                @PathVariable Long lectureId,
-                                                                @AuthenticationPrincipal UserDetailsImpl userDetails) {
+                                              @PathVariable Long lectureId,
+                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
         commentService.createComment(requestDto, lectureId, userDetails);
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @PutMapping("/lectures/comments/{commentId}")
+    public ResponseEntity<Void> updateComment(@RequestBody CommentUpdateRequestDto requestDto,
+                                              @PathVariable Long commentId,
+                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentService.updateComment(requestDto, commentId, userDetails);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/controller/CommentController.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/controller/CommentController.java
@@ -31,4 +31,11 @@ public class CommentController {
         commentService.updateComment(requestDto, commentId, userDetails);
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
+    @DeleteMapping("/lectures/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId,
+                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentService.deleteComment(commentId, userDetails);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/controller/CommentController.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/controller/CommentController.java
@@ -1,0 +1,28 @@
+package com.sparta.spartalecture.comment.controller;
+
+import com.sparta.spartalecture.comment.dto.CommentCreateRequestDto;
+import com.sparta.spartalecture.comment.service.CommentService;
+import com.sparta.spartalecture.security.service.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/lectures/{lectureId}/comments")
+    public ResponseEntity<Void> createComment(@RequestBody CommentCreateRequestDto requestDto,
+                                                                @PathVariable Long lectureId,
+                                                                @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentService.createComment(requestDto, lectureId, userDetails);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/domain/Comment.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/domain/Comment.java
@@ -1,0 +1,40 @@
+package com.sparta.spartalecture.comment.domain;
+
+import com.sparta.spartalecture.comment.dto.CommentCreateRequestDto;
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.lecture.domain.Timestamped;
+import com.sparta.spartalecture.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "comment")
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Comment extends Timestamped {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id")
+    private Lecture lecture;
+
+    @Column(name = "content", nullable = false, length = 150)
+    private String content;
+
+    public static Comment of(CommentCreateRequestDto requestDto, Lecture lecture, User user) {
+        return Comment.builder()
+                .user(user)
+                .lecture(lecture)
+                .content(requestDto.getContent())
+                .build();
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/domain/Comment.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/domain/Comment.java
@@ -1,6 +1,7 @@
 package com.sparta.spartalecture.comment.domain;
 
 import com.sparta.spartalecture.comment.dto.CommentCreateRequestDto;
+import com.sparta.spartalecture.comment.dto.CommentUpdateRequestDto;
 import com.sparta.spartalecture.lecture.domain.Lecture;
 import com.sparta.spartalecture.lecture.domain.Timestamped;
 import com.sparta.spartalecture.user.domain.User;
@@ -36,5 +37,9 @@ public class Comment extends Timestamped {
                 .lecture(lecture)
                 .content(requestDto.getContent())
                 .build();
+    }
+
+    public void update(CommentUpdateRequestDto requestDto) {
+        this.content = requestDto.getContent();
     }
 }

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/dto/CommentCreateRequestDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/dto/CommentCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.sparta.spartalecture.comment.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CommentCreateRequestDto {
+
+    @NotBlank(message = "값이 입력되지 않았습니다")
+    @Max(value = 150, message = "최대 150자까지 입력할 수 있습니다")
+    private String content;
+
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/dto/CommentInfoResponseDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/dto/CommentInfoResponseDto.java
@@ -1,0 +1,29 @@
+package com.sparta.spartalecture.comment.dto;
+
+import com.sparta.spartalecture.comment.domain.Comment;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CommentInfoResponseDto {
+
+    private Long commentId;
+    private Long userId;
+    private Long lectureId;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static CommentInfoResponseDto from(Comment comment) {
+        return CommentInfoResponseDto.builder()
+                .commentId(comment.getId())
+                .userId(comment.getUser().getId())
+                .lectureId(comment.getLecture().getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/dto/CommentUpdateRequestDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/dto/CommentUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.sparta.spartalecture.comment.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CommentUpdateRequestDto {
+
+    @NotBlank(message = "값이 입력되지 않았습니다")
+    @Max(value = 150, message = "최대 150자까지 입력할 수 있습니다")
+    private String content;
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/repository/CommentRepository.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.spartalecture.comment.repository;
+
+import com.sparta.spartalecture.comment.domain.Comment;
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByLecture(Lecture lecture);
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/service/CommentService.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/service/CommentService.java
@@ -1,0 +1,34 @@
+package com.sparta.spartalecture.comment.service;
+
+import com.sparta.spartalecture.comment.domain.Comment;
+import com.sparta.spartalecture.comment.dto.CommentCreateRequestDto;
+import com.sparta.spartalecture.comment.repository.CommentRepository;
+import com.sparta.spartalecture.global.exception.CustomException;
+import com.sparta.spartalecture.global.exception.CustomExceptionCode;
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.lecture.repository.LectureRepository;
+import com.sparta.spartalecture.security.service.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final LectureRepository lectureRepository;
+
+    public void createComment(CommentCreateRequestDto requestDto, Long lectureId, UserDetailsImpl userDetails) {
+        // 강의 존재 여부 판별
+        Lecture lecture = findLecture(lectureId);
+
+        // 댓글 save
+        Comment comment = Comment.of(requestDto, lecture,userDetails.getUser());
+        commentRepository.save(comment);
+    }
+
+    private Lecture findLecture(Long lectureId) {
+        return lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.LECTURE_NOT_FOUND));
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/service/CommentService.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/comment/service/CommentService.java
@@ -45,6 +45,20 @@ public class CommentService {
         comment.update(requestDto);
     }
 
+    public void deleteComment(Long commentId, UserDetailsImpl userDetails) {
+        // 댓글 존재 여부 판별
+        Comment comment = findComment(commentId);
+
+        // 동일한 작성자인지 판별
+        Long writerId = comment.getUser().getId();
+        Long userId = userDetails.getUser().getId();
+        if (!writerId.equals(userId)) {
+            throw new CustomException(CustomExceptionCode.COMMENT_ACCESS_DENIED);
+        }
+
+        commentRepository.delete(comment);
+    }
+
     private Lecture findLecture(Long lectureId) {
         return lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new CustomException(CustomExceptionCode.LECTURE_NOT_FOUND));

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/global/exception/CustomExceptionCode.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/global/exception/CustomExceptionCode.java
@@ -10,7 +10,9 @@ public enum CustomExceptionCode {
 
     MEMBER_EXISTS(HttpStatus.CONFLICT, "해당 이메일의 회원이 이미 존재합니다."),
     TEACHER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강사는 존재하지 않습니다."),
-    LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강의는 존재하지 않습니다.");
+    LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강의는 존재하지 않습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글은 존재하지 않습니다."),
+    COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 댓글 작성자만 작업할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureInfoResponseDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureInfoResponseDto.java
@@ -1,11 +1,13 @@
 package com.sparta.spartalecture.lecture.dto;
 
+import com.sparta.spartalecture.comment.dto.CommentInfoResponseDto;
 import com.sparta.spartalecture.lecture.domain.Lecture;
 import com.sparta.spartalecture.lecture.type.Category;
 import com.sparta.spartalecture.teacher.dto.TeacherInfoResponseDto;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -20,8 +22,9 @@ public class LectureInfoResponseDto {
     private Category category;
     private LocalDateTime createdAt;
     private TeacherInfoResponseDto teacher;
+    private List<CommentInfoResponseDto> commentList;
 
-    public static LectureInfoResponseDto from(Lecture lecture) {
+    public static LectureInfoResponseDto of(Lecture lecture, List<CommentInfoResponseDto> commentList) {
         return LectureInfoResponseDto.builder()
                 .id(lecture.getId())
                 .title(lecture.getTitle())
@@ -30,6 +33,7 @@ public class LectureInfoResponseDto {
                 .category(lecture.getCategory())
                 .createdAt(lecture.getCreatedAt())
                 .teacher(TeacherInfoResponseDto.from(lecture.getTeacher()))
+                .commentList(commentList)
                 .build();
     }
 }

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
@@ -1,5 +1,8 @@
 package com.sparta.spartalecture.lecture.service;
 
+import com.sparta.spartalecture.comment.domain.Comment;
+import com.sparta.spartalecture.comment.dto.CommentInfoResponseDto;
+import com.sparta.spartalecture.comment.repository.CommentRepository;
 import com.sparta.spartalecture.global.exception.CustomException;
 import com.sparta.spartalecture.global.exception.CustomExceptionCode;
 import com.sparta.spartalecture.lecture.domain.Lecture;
@@ -18,12 +21,16 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class LectureService {
 
     private final LectureRepository lectureRepository;
     private final TeacherRepository teacherRepository;
+    private final CommentRepository commentRepository;
 
     public LectureRegistrationResponseDto registerLecture(LectureRegistrationRequestDto requestDto) {
 
@@ -38,7 +45,14 @@ public class LectureService {
 
     public LectureInfoResponseDto getLecture(Long lectureId) {
         Lecture lecture = findLecture(lectureId);
-        return LectureInfoResponseDto.from(lecture);
+
+        List<Comment> commentList = commentRepository.findAllByLecture(lecture);
+        List<CommentInfoResponseDto> commentInfoResponseDtoList = new ArrayList<>();
+        for (Comment comment : commentList) {
+            commentInfoResponseDtoList.add(CommentInfoResponseDto.from(comment));
+        }
+
+        return LectureInfoResponseDto.of(lecture, commentInfoResponseDtoList);
     }
 
     public Page<LectureInfoByCategoryDto> getLecturesByCategory(Category category, int page, int size, String sortBy, boolean isAsc) {

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/security/config/SecurityConfig.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/security/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                 (authorizeHttpRequests) -> authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers("/admins/**").hasRole("ADMIN")
+                        .requestMatchers("/comments/**").hasAnyRole("USER", "ADMIN")
                         .requestMatchers("/users/**").permitAll()
                         .requestMatchers("/lectures/**").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
### 요약
선택한 강의 댓글 작성 기능, 선택한 강의 선택한 댓글 수정 기능, 선택한 강의 선택한 댓글 삭제 기능 구현

### 작업사항
- 선택한 강의 댓글 작성 api 구현
- 선택한 강의 조회 시 댓글 목록도 함께 조회할 수 있도록 강의 response dto 수정
- 선택한 강의의 선택한 댓글 수정 api 구현
- 선택한 강의의 선택한 댓글 삭제 api 구현
- 수정과 삭제 기능은 댓글 작성자만 작업할 수 있도록 판별 로직과 예외 처리 구현

### 완료사항
- [x]  선택한 강의 댓글 기능
    - 선택한 강의에 댓글을 등록할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - 회원만 댓글 등록이 가능합니다.
    - 댓글 등록 성공을 확인할 수 있는 값을 반환합니다.
        - ex) HTTP Status Code, Error Message …
    - 선택한 강의를 조회할 때 해당 강의에 등록된 댓글들도 함께 조회할 수 있습니다.
- [x]  선택한 강의의 선택한 댓글 수정 기능
    - 선택한 강의의 선택한 댓글을 수정할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - 해당 댓글을 등록한 회원만 댓글 수정이 가능합니다.
    - 댓글 수정 성공을 확인할 수 있는 값을 반환합니다.
        - ex) HTTP Status Code, Error Message …
- [x]  선택한 강의의 선택한 댓글 삭제 기능
    - 선택한 강의의 선택한 댓글을 삭제할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - 해당 댓글을 등록한 회원만 댓글 삭제가 가능합니다.
    - 댓글 삭제 성공을 확인할 수 있는 값을 반환합니다.
        - ex) HTTP Status Code, Error Message …