### PR TITLE
✨선택한 강의 좋아요 기능

### DIFF
--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureInfoResponseDto.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/dto/LectureInfoResponseDto.java
@@ -23,8 +23,9 @@ public class LectureInfoResponseDto {
     private LocalDateTime createdAt;
     private TeacherInfoResponseDto teacher;
     private List<CommentInfoResponseDto> commentList;
+    private int likeCount;
 
-    public static LectureInfoResponseDto of(Lecture lecture, List<CommentInfoResponseDto> commentList) {
+    public static LectureInfoResponseDto of(Lecture lecture, List<CommentInfoResponseDto> commentList, int likeCount) {
         return LectureInfoResponseDto.builder()
                 .id(lecture.getId())
                 .title(lecture.getTitle())
@@ -34,6 +35,7 @@ public class LectureInfoResponseDto {
                 .createdAt(lecture.getCreatedAt())
                 .teacher(TeacherInfoResponseDto.from(lecture.getTeacher()))
                 .commentList(commentList)
+                .likeCount(likeCount)
                 .build();
     }
 }

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/lecture/service/LectureService.java
@@ -12,6 +12,7 @@ import com.sparta.spartalecture.lecture.dto.LectureRegistrationRequestDto;
 import com.sparta.spartalecture.lecture.dto.LectureRegistrationResponseDto;
 import com.sparta.spartalecture.lecture.repository.LectureRepository;
 import com.sparta.spartalecture.lecture.type.Category;
+import com.sparta.spartalecture.like.repository.LikeLectureRepository;
 import com.sparta.spartalecture.teacher.domain.Teacher;
 import com.sparta.spartalecture.teacher.repository.TeacherRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ public class LectureService {
     private final LectureRepository lectureRepository;
     private final TeacherRepository teacherRepository;
     private final CommentRepository commentRepository;
+    private final LikeLectureRepository likeLectureRepository;
 
     public LectureRegistrationResponseDto registerLecture(LectureRegistrationRequestDto requestDto) {
 
@@ -52,7 +54,9 @@ public class LectureService {
             commentInfoResponseDtoList.add(CommentInfoResponseDto.from(comment));
         }
 
-        return LectureInfoResponseDto.of(lecture, commentInfoResponseDtoList);
+        int likeCount = likeLectureRepository.countByLecture(lecture);
+
+        return LectureInfoResponseDto.of(lecture, commentInfoResponseDtoList, likeCount);
     }
 
     public Page<LectureInfoByCategoryDto> getLecturesByCategory(Category category, int page, int size, String sortBy, boolean isAsc) {

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/like/controller/LikeLectureController.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/like/controller/LikeLectureController.java
@@ -1,0 +1,25 @@
+package com.sparta.spartalecture.like.controller;
+
+import com.sparta.spartalecture.like.service.LikeLectureService;
+import com.sparta.spartalecture.security.service.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LikeLectureController {
+
+    private final LikeLectureService likeLectureService;
+
+    @PostMapping("/lectures/{lectureId}/like")
+    public ResponseEntity<Void> toggleLike(@PathVariable Long lectureId,
+                                           @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        likeLectureService.toggleLike(lectureId, userDetails);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/like/domain/LikeLecture.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/like/domain/LikeLecture.java
@@ -1,0 +1,37 @@
+package com.sparta.spartalecture.like.domain;
+
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "likelecture")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class LikeLecture {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "lecturelike_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id")
+    private Lecture lecture;
+
+
+    public static LikeLecture of(Lecture lecture, User user) {
+        return LikeLecture.builder()
+                .user(user)
+                .lecture(lecture)
+                .build();
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/like/repository/LikeLectureRepository.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/like/repository/LikeLectureRepository.java
@@ -1,0 +1,14 @@
+package com.sparta.spartalecture.like.repository;
+
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.like.domain.LikeLecture;
+import com.sparta.spartalecture.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LikeLectureRepository extends JpaRepository<LikeLecture, Long> {
+    int countByLecture(Lecture lecture);
+
+    Optional<LikeLecture> findByUserAndLecture(User user, Lecture lecture);
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/like/service/LikeLectureService.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/like/service/LikeLectureService.java
@@ -1,0 +1,40 @@
+package com.sparta.spartalecture.like.service;
+
+import com.sparta.spartalecture.global.exception.CustomException;
+import com.sparta.spartalecture.global.exception.CustomExceptionCode;
+import com.sparta.spartalecture.lecture.domain.Lecture;
+import com.sparta.spartalecture.lecture.repository.LectureRepository;
+import com.sparta.spartalecture.like.domain.LikeLecture;
+import com.sparta.spartalecture.like.repository.LikeLectureRepository;
+import com.sparta.spartalecture.security.service.UserDetailsImpl;
+import com.sparta.spartalecture.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeLectureService {
+
+    private final LikeLectureRepository likeLectureRepository;
+    private final LectureRepository lectureRepository;
+
+    public void toggleLike(Long lectureId, UserDetailsImpl userDetails) {
+        Lecture lecture = findLecture(lectureId);
+        User user = userDetails.getUser();
+
+        Optional<LikeLecture> optionalLikeLecture = likeLectureRepository.findByUserAndLecture(user, lecture);
+        if (optionalLikeLecture.isEmpty()) {
+            LikeLecture likeLecture = LikeLecture.of(lecture, user);
+            likeLectureRepository.save(likeLecture);
+        } else {
+            likeLectureRepository.delete(optionalLikeLecture.get());
+        }
+    }
+
+    private Lecture findLecture(Long lectureId) {
+        return lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.LECTURE_NOT_FOUND));
+    }
+}

--- a/sparta-lecture/src/main/java/com/sparta/spartalecture/security/config/SecurityConfig.java
+++ b/sparta-lecture/src/main/java/com/sparta/spartalecture/security/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers("/admins/**").hasRole("ADMIN")
                         .requestMatchers("/comments/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/like").hasAnyRole("USER", "ADMIN")
                         .requestMatchers("/users/**").permitAll()
                         .requestMatchers("/lectures/**").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
### 요약
선택한 강의 좋아요 기능 구현

### 작업사항
- 선택한 강의 좋아요 api 구현
- 이미 해당 강의에 좋아요를 한 상태라면 좋아요가 취소되도록 toggleLike 메서드를 구현
- 선택한 강의를 조회할 때 해당 강의의 좋아요 수를 함께 조회할 수 있도록 LectureInfoResponseDto에 likeCount 필드 추가 및 로직 구현

### 완료사항
- [x]  선택한 강의 좋아요 기능
    - 선택한 강의에 좋아요를 등록할 수 있습니다.
        - 로그인을 통해 발급받은 JWT가 함께 요청됩니다.
        - 회원만 좋아요 등록이 가능합니다.
        - 이미 해당 강의에 좋아요를 한 상태라면 좋아요가 취소됩니다.
    - 좋아요 등록/취소 성공을 확인할 수 있는 값을 반환합니다.
        - ex) HTTP Status Code, Error Message …
    - 선택한 강의를 조회할 때 해당 강의의 좋아요 수를 함께 조회할 수 있습니다.